### PR TITLE
libval/dane: Fix invalid X509_STORE call

### DIFF
--- a/dnssec-tools/validator/libval/val_dane.c
+++ b/dnssec-tools/validator/libval/val_dane.c
@@ -876,7 +876,7 @@ val_X509_peer_cert_verify_cb(X509_STORE_CTX *x509ctx, void *arg)
         return 0;
 
     
-    cert = X509_STORE_CTX_get_current_cert(x509ctx);
+    cert = X509_STORE_CTX_get0_cert(x509ctx);
     context = ssl_dane_data->context;
 
     /* 


### PR DESCRIPTION
Use X509_STORE_CTX_get0_cert as we need to fetch the certificate being verified.

X509_STORE_CTX_get_current_cert returns the certificate which caused a verify error or NULL. This is not what we want.