### PR TITLE
Fix for possible segmentation fault

### DIFF
--- a/dnssec-tools/validator/libval/val_assertion.c
+++ b/dnssec-tools/validator/libval/val_assertion.c
@@ -3482,10 +3482,12 @@ prove_nonexistence(val_context_t * ctx,
     /*
      * free actual results 
      */
-    val_free_result_chain(*results);
-    *results = NULL;
-    val_free_result_chain(*proof_res);
-    *proof_res = NULL;
+    if (retval != VAL_NO_ERROR) {
+        val_free_result_chain(*results);
+        *results = NULL;
+        val_free_result_chain(*proof_res);
+        *proof_res = NULL;
+    }
     return retval;
 }
 


### PR DESCRIPTION
dt-validator call with given parameters
dt-validate -o 6:stdout nonexistent.olis.bank
causes a crash of dt-validator tool.

